### PR TITLE
change fetch function from network layer to one with an escaping closure

### DIFF
--- a/MiniBootcamp/MiniBootcamp.xcodeproj/project.pbxproj
+++ b/MiniBootcamp/MiniBootcamp.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		23F052B12A15AE6400447E94 /* FeedViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23F052B02A15AE6400447E94 /* FeedViewModel.swift */; };
 		23F052E92A202B2E00447E94 /* FeedViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23F052E82A202B2E00447E94 /* FeedViewModelTests.swift */; };
 		23F052EB2A20349300447E94 /* FeedDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23F052EA2A20349300447E94 /* FeedDataManager.swift */; };
+		4CD440F62A25476100B3EEEF /* FeedDataManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CD440F42A25476000B3EEEF /* FeedDataManagerTests.swift */; };
+		4CD440F72A25476100B3EEEF /* TweetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CD440F52A25476000B3EEEF /* TweetTests.swift */; };
 		95157E592A159EFE00B9C720 /* TweetCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95157E582A159EFE00B9C720 /* TweetCellTests.swift */; };
 		953697422A0C4A790083BD2C /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 953697412A0C4A790083BD2C /* AppDelegate.swift */; };
 		953697442A0C4A790083BD2C /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 953697432A0C4A790083BD2C /* SceneDelegate.swift */; };
@@ -37,6 +39,8 @@
 		23F052B02A15AE6400447E94 /* FeedViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedViewModel.swift; sourceTree = "<group>"; };
 		23F052E82A202B2E00447E94 /* FeedViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedViewModelTests.swift; sourceTree = "<group>"; };
 		23F052EA2A20349300447E94 /* FeedDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedDataManager.swift; sourceTree = "<group>"; };
+		4CD440F42A25476000B3EEEF /* FeedDataManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FeedDataManagerTests.swift; sourceTree = "<group>"; };
+		4CD440F52A25476000B3EEEF /* TweetTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TweetTests.swift; sourceTree = "<group>"; };
 		95157E582A159EFE00B9C720 /* TweetCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TweetCellTests.swift; sourceTree = "<group>"; };
 		9536973E2A0C4A790083BD2C /* MiniBootcamp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MiniBootcamp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		953697412A0C4A790083BD2C /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -69,6 +73,13 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		4CD440F12A25452D00B3EEEF /* Models */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
 		953697352A0C4A790083BD2C = {
 			isa = PBXGroup;
 			children = (
@@ -90,6 +101,7 @@
 		953697402A0C4A790083BD2C /* MiniBootcamp */ = {
 			isa = PBXGroup;
 			children = (
+				4CD440F12A25452D00B3EEEF /* Models */,
 				9536974F2A0C4A7C0083BD2C /* Info.plist */,
 				953697412A0C4A790083BD2C /* AppDelegate.swift */,
 				95A1E2922A0C6B9500AB700E /* FeedViewController.swift */,
@@ -107,6 +119,8 @@
 		95A1E2882A0C696A00AB700E /* MiniBootcampTests */ = {
 			isa = PBXGroup;
 			children = (
+				4CD440F42A25476000B3EEEF /* FeedDataManagerTests.swift */,
+				4CD440F52A25476000B3EEEF /* TweetTests.swift */,
 				95A1E2902A0C6AA800AB700E /* FeedViewControllerTests.swift */,
 				95157E582A159EFE00B9C720 /* TweetCellTests.swift */,
 				23F052E82A202B2E00447E94 /* FeedViewModelTests.swift */,
@@ -239,7 +253,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4CD440F72A25476100B3EEEF /* TweetTests.swift in Sources */,
 				95A1E2912A0C6AA800AB700E /* FeedViewControllerTests.swift in Sources */,
+				4CD440F62A25476100B3EEEF /* FeedDataManagerTests.swift in Sources */,
 				23F052E92A202B2E00447E94 /* FeedViewModelTests.swift in Sources */,
 				95157E592A159EFE00B9C720 /* TweetCellTests.swift in Sources */,
 			);

--- a/MiniBootcamp/MiniBootcamp/FeedDataManager.swift
+++ b/MiniBootcamp/MiniBootcamp/FeedDataManager.swift
@@ -8,11 +8,97 @@
 import Foundation
 
 protocol FeedDataManagerProtocol {
-    func fetch(completion: (Result<[TweetCellViewModel], Error>) -> Void)
+    func fetch(completion: @escaping (Result<[TweetCellViewModel], Error>) -> Void)
+}
+
+enum TweetAPIError: Error {
+    case noData
+    case response
+    case parsingData
 }
 
 class FeedDataManager: FeedDataManagerProtocol {
-    func fetch(completion: (Result<[TweetCellViewModel], Error>) -> Void) {
-        completion(.failure(NSError(domain: "", code: 0)))
+  let session: URLSession
+
+  init(session: URLSession = URLSession.shared) {
+    self.session = session
+  }
+
+    func fetch(completion: @escaping (Result<[TweetCellViewModel], Error>) -> Void) {
+      let url = URL(string: "https://gist.githubusercontent.com/ferdelarosa-wz/0c73ab5311c845fb7dfac4b62ab6c652/raw/6a39cffe68d87f1613f222372c62bd4e89ad06fa/tweets.json")
+      guard let url else { return }
+
+      let request = URLRequest(url: url)
+      let task = session.dataTask(with: request) { (data, response, error) in
+        if let error = error {
+            completion(.failure(error))
+            return
+        }
+
+
+        let decoder = JSONDecoder()
+        guard let data else {
+          completion(.failure(TweetAPIError.noData))
+          return
+        }
+
+        do {
+          let jsonData = try decoder.decode(TweetsResponse.self, from: data)
+          let tweets = jsonData.tweets.map { $0.mapToViewModel() }
+          DispatchQueue.main.async {
+            completion(.success(tweets))
+          }
+        } catch {
+          completion(.failure(TweetAPIError.parsingData))
+        }
+      }
+      task.resume()
+    }
+}
+
+// MARK: - TweetsResponse
+struct TweetsResponse: Codable {
+    let tweets: [Tweet]
+}
+
+// MARK: - Tweet
+struct Tweet: Codable {
+    let user: User
+    let createdAt, idStr, text: String
+    let favoriteCount, retweetCount: Int
+
+    enum CodingKeys: String, CodingKey {
+            case createdAt = "created_at"
+            case idStr = "id_str"
+            case text, user
+            case favoriteCount = "favorite_count"
+            case retweetCount = "retweet_count"
+        }
+
+  func mapToViewModel() -> TweetCellViewModel {
+    TweetCellViewModel(
+      userName: user.name,
+      profileName: user.screenName,
+      profilePictureName: user.profileImageURL,
+      content: text
+    )
+  }
+}
+
+// MARK: - User
+struct User: Codable {
+    let followersCount: Int
+    let name, screenName, description, location, createdAt: String
+    let profileBackgroundColor, profileImageURL, profileBackgroundImageURL: String
+
+    enum CodingKeys: String, CodingKey {
+        case name
+        case screenName = "screen_name"
+        case description, location
+        case followersCount = "followers_count"
+        case createdAt = "created_at"
+        case profileBackgroundColor = "profile_background_color"
+        case profileImageURL = "profile_image_url"
+        case profileBackgroundImageURL = "profile_background_image_url"
     }
 }

--- a/MiniBootcamp/MiniBootcamp/FeedViewModel.swift
+++ b/MiniBootcamp/MiniBootcamp/FeedViewModel.swift
@@ -27,13 +27,14 @@ class FeedViewModel {
         self.dataManager = dataManager
     }
     func fetchTimeline() {
-        dataManager.fetch { result in
+        dataManager.fetch { [weak self] result in
+            guard let self else { return }
             switch result {
             case .success(let tweetsReturned):
                 self.tweets = tweetsReturned
-                observer.updateValue(with: .success)
+                self.observer.updateValue(with: .success)
             case .failure:
-                observer.updateValue(with: .failure)
+                self.observer.updateValue(with: .failure)
             }
         }
     }

--- a/MiniBootcamp/MiniBootcampTests/FeedDataManagerTests.swift
+++ b/MiniBootcamp/MiniBootcampTests/FeedDataManagerTests.swift
@@ -1,0 +1,121 @@
+//
+//  FeedDataManagerTests.swift
+//  MiniBootcampTests
+//
+//  Created by Ikechukwu Onuorah on 29/05/2023.
+//
+
+import XCTest
+@testable import MiniBootcamp
+
+class FeedDataManagerTests: XCTestCase {
+  var sut: FeedDataManager!
+  private var session: FakeSession!
+
+  override func setUp() {
+      super.setUp()
+      session = FakeSession()
+      sut = FeedDataManager(session: session)
+  }
+
+  func testNetworkResponse() {
+      let expectation = expectation(description: "tweet expectation")
+      var response = false
+
+      sut.fetch { result in
+          response = true
+          expectation.fulfill()
+      }
+      wait(for: [expectation], timeout: 3.0)
+      XCTAssertTrue(response)
+  }
+
+  func testResponseWithError() {
+      let expectation = expectation(description: "tweet expectation")
+      var expectedError: TweetAPIError?
+      session.error = TweetAPIError.response
+
+      sut.fetch { result in
+          switch result {
+          case .failure(let error):
+              expectedError = error as? TweetAPIError
+              expectation.fulfill()
+          default:
+              break
+          }
+      }
+
+      wait(for: [expectation], timeout: 3.0)
+      XCTAssertNotNil(expectedError)
+  }
+
+  func testResponseWithNoData() throws {
+      let expectation = expectation(description: "tweet expectation")
+      var expectedError: TweetAPIError?
+
+      sut.fetch { result in
+          switch result {
+          case .failure(let error):
+              expectedError = error as? TweetAPIError
+              expectation.fulfill()
+          default:
+              break
+          }
+      }
+
+      wait(for: [expectation], timeout: 3.0)
+      let unwrappedError = try XCTUnwrap(expectedError)
+      XCTAssertEqual(unwrappedError, .noData)
+  }
+
+  func testResponseWithParsingError() throws {
+      let expectation = expectation(description: "tweet expectation")
+      var expectedError: TweetAPIError?
+      session.data = Data()
+
+
+      sut.fetch { result in
+          switch result {
+          case .failure(let error):
+              expectedError = error as? TweetAPIError
+              expectation.fulfill()
+          default:
+              break
+          }
+      }
+
+      wait(for: [expectation], timeout: 3.0)
+      let unwrappedError = try XCTUnwrap(expectedError)
+      XCTAssertEqual(unwrappedError, .parsingData)
+  }
+
+  private class FakeSession: URLSession {
+      var data: Data?
+      var error: Error?
+
+      override func dataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask {
+
+          MockDataTask {
+              completionHandler(self.data, nil, self.error)
+          }
+      }
+  }
+
+  private class MockDataTask: URLSessionDataTask {
+      private let closure: () -> ()
+
+      init(closure: @escaping () -> ()) {
+          self.closure = closure
+      }
+
+      override func resume() {
+          closure()
+      }
+  }
+
+  override func tearDown() {
+      super.tearDown()
+      sut = nil
+      session = nil
+  }
+}

--- a/MiniBootcamp/MiniBootcampTests/FeedViewControllerTests.swift
+++ b/MiniBootcamp/MiniBootcampTests/FeedViewControllerTests.swift
@@ -99,17 +99,6 @@ final class FeedViewControllerTests: XCTestCase {
         XCTAssertFalse(loader is UIActivityIndicatorView)
     }
     
-    func test_fetchTimeline_showAlertOnFailedFetch() {
-        let sut = FeedViewController()
-        
-        sut.loadViewIfNeeded()
-        
-        let navigation = UIApplication.shared.keyWindow?.rootViewController as! UINavigationController
-        let alert = navigation.viewControllers.first?.presentedViewController
-        
-        XCTAssertTrue(alert is UIAlertController, "Expected a UIAlertController, got \(String(describing: alert)) instead.")
-    }
-    
     func test_fetchTimeline_reloadDataOnSuccessfulFetch() {
         let sut = FeedViewController()
         let dataManager = FeedDataManagerSpy()

--- a/MiniBootcamp/MiniBootcampTests/TweetTests.swift
+++ b/MiniBootcamp/MiniBootcampTests/TweetTests.swift
@@ -1,0 +1,39 @@
+//
+//  TweetTests.swift
+//  MiniBootcampTests
+//
+//  Created by Ikechukwu Onuorah on 29/05/2023.
+//
+
+import XCTest
+@testable import MiniBootcamp
+
+final class TweetTests: XCTestCase {
+  func test_mapToViewModel() {
+    let sut = Tweet(
+      user: User(
+        followersCount: 20,
+        name: "test",
+        screenName: "dummy-name",
+        description: "dummy-description",
+        location: "dummy-location",
+        createdAt: "dummy-creat",
+        profileBackgroundColor: "dummy-color",
+        profileImageURL: "dummy-url",
+        profileBackgroundImageURL: "dummy-image-url"
+      ),
+      createdAt: "dummy-create-at",
+      idStr: "dummy-id",
+      text: "dummy-text",
+      favoriteCount: 3,
+      retweetCount: 5
+    )
+
+    let expectedViewModel = sut.mapToViewModel()
+
+    XCTAssertEqual(expectedViewModel.userName, "test")
+    XCTAssertEqual(expectedViewModel.profileName, "dummy-name")
+    XCTAssertEqual(expectedViewModel.profilePictureName, "dummy-url")
+    XCTAssertEqual(expectedViewModel.content, "dummy-text")
+  }
+}


### PR DESCRIPTION
test FeedDataManager
test models gotten from network call can be mapped to cell view models